### PR TITLE
[enh] #754: replace .catch() by try/catch for better error handling.

### DIFF
--- a/server.js
+++ b/server.js
@@ -330,45 +330,46 @@ function Server (dbConf, overrideConf) {
 
   function resetFiles(files, dirs, done) {
     return co(function *() {
-      const params = yield paramsP;
-      const myFS = params.fs;
-      const rootPath = params.home;
-      for (const fName of files) {
-        // JSON file?
-        const existsJSON = yield myFS.exists(rootPath + '/' + fName + '.json');
-        if (existsJSON) {
-          const theFilePath = rootPath + '/' + fName + '.json';
-          yield myFS.remove(theFilePath);
-          if (yield myFS.exists(theFilePath)) {
-            throw Error('Failed to delete file "' + theFilePath + '"');
-          }
-        } else {
-          // Normal file?
-          const normalFile = path.join(rootPath, fName);
-          const existsFile = yield myFS.exists(normalFile);
-          if (existsFile) {
-            yield myFS.remove(normalFile);
-            if (yield myFS.exists(normalFile)) {
-              throw Error('Failed to delete file "' + normalFile + '"');
+      try {
+        const params = yield paramsP;
+        const myFS = params.fs;
+        const rootPath = params.home;
+        for (const fName of files) {
+          // JSON file?
+          const existsJSON = yield myFS.exists(rootPath + '/' + fName + '.json');
+          if (existsJSON) {
+            const theFilePath = rootPath + '/' + fName + '.json';
+            yield myFS.remove(theFilePath);
+            if (yield myFS.exists(theFilePath)) {
+              throw Error('Failed to delete file "' + theFilePath + '"');
+            }
+          } else {
+            // Normal file?
+            const normalFile = path.join(rootPath, fName);
+            const existsFile = yield myFS.exists(normalFile);
+            if (existsFile) {
+              yield myFS.remove(normalFile);
+              if (yield myFS.exists(normalFile)) {
+                throw Error('Failed to delete file "' + normalFile + '"');
+              }
             }
           }
         }
-      }
-      for (const dirName of dirs) {
-        const existsDir = yield myFS.exists(rootPath + '/' + dirName);
-        if (existsDir) {
-          yield myFS.removeTree(rootPath + '/' + dirName);
-          if (yield myFS.exists(rootPath + '/' + dirName)) {
-            throw Error('Failed to delete folder "' + rootPath + '/' + dirName + '"');
+        for (const dirName of dirs) {
+          const existsDir = yield myFS.exists(rootPath + '/' + dirName);
+          if (existsDir) {
+            yield myFS.removeTree(rootPath + '/' + dirName);
+            if (yield myFS.exists(rootPath + '/' + dirName)) {
+              throw Error('Failed to delete folder "' + rootPath + '/' + dirName + '"');
+            }
           }
         }
+        done && done();
+    } catch(e) {
+          done && done(e);
+          throw e;
       }
-      done && done();
-    })
-        .catch((err) => {
-          done && done(err);
-          throw err;
-        });
+    });
   }
 
   this.disconnect = () => Promise.resolve(that.dal && that.dal.close());


### PR DESCRIPTION
I couldn't do it for ever parts of the code because some syntax was hard to me to understand and modify.

Here is new errors which I hope come from the fact that errors are now displayed and not from this refactoring.

```bash
✖ 246 problems (7 errors, 239 warnings)

  

  2) Revert memberships revert 2 neutral blocks for i3:
     AssertionError: expected Array [
  Object {
    membership: 'IN',
    issuer: 'HgTTJLAQ5sqfknMq7yLPZbehtuLSsKj9CxWN7k8QvYJd',
    number: 4,
    blockNumber: 4,
    blockHash: 'AF8EC916D4C9DA854E0DBED7659D36790F80D1A53949C8B6D0224CC75DF6C005',
    userid: 'i1',
    certts: '0-E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855',
    block: '4-AF8EC916D4C9DA854E0DBED7659D36790F80D1A53949C8B6D0224CC75DF6C005',
    fpr: 'AF8EC916D4C9DA854E0DBED7659D36790F80D1A53949C8B6D0224CC75DF6C005',
    idtyHash: 'EB8CF29D90558A9AEDD69B736A8661801D3E2309F54A822F5AFACC0A352E2A8C',
    written: false,
    written_number: null,
    signature: '3I25FLcYwTLPon4Cd2nZSAr0qPLptsNZBKg4SbPD8aAgVkzIJQH1IKl3KACitvcv9lOovha7GtfDSfE0PVcABA==',
    expired: null
  },
  Object {
    membership: 'IN',
    issuer: 'DKpQPUL4ckzXYdnDRvCRKAm1gNvSdmAXnTrJZ7LvM5Qo',
    number: 8,
    blockNumber: 8,
    blockHash: 'F47B4FDC82C68B8DD496F490D5DB21489B25C976783E3A2463EF4FEFAB744715',
    userid: 'i3',
    certts: '1-1ACDD3747D432ECF94548C57D13357330AF3382433B690725D63A427419BB195',
    block: '8-F47B4FDC82C68B8DD496F490D5DB21489B25C976783E3A2463EF4FEFAB744715',
    fpr: 'F47B4FDC82C68B8DD496F490D5DB21489B25C976783E3A2463EF4FEFAB744715',
    idtyHash: '40BF3D4A5FEFA84429B975D84C112E6597218B60E098FF19303EEBD9A30B0D32',
    written: false,
    written_number: null,
    signature: 'S4Wyj7lvw3Nya6QxuVpZph+qWQHkXHd19E9iej4AA7RoiY+efLM/AaHL5JRgOxM+l/QngefcLh29X0WDMfdrBQ==',
    expired: null
  },
  Object {
    membership: 'OUT',
    issuer: 'DKpQPUL4ckzXYdnDRvCRKAm1gNvSdmAXnTrJZ7LvM5Qo',
    number: 5,
    blockNumber: 5,
    blockHash: '295D0E724BADE47FABD8F8BF96F7740682A744331205CBBB1BF0C58354DBA157',
    userid: 'i3',
    certts: '1-1ACDD3747D432ECF94548C57D13357330AF3382433B690725D63A427419BB195',
    block: '5-295D0E724BADE47FABD8F8BF96F7740682A744331205CBBB1BF0C58354DBA157',
    fpr: '295D0E724BADE47FABD8F8BF96F7740682A744331205CBBB1BF0C58354DBA157',
    idtyHash: '40BF3D4A5FEFA84429B975D84C112E6597218B60E098FF19303EEBD9A30B0D32',
    written: false,
    written_number: null,
    signature: 'qtq5qfnEVFdswTqqhtpGagz2qUsqFAt7Orc6eRDIkLMeS+h1xJpXNUm7vrYYKj69HKQqGerVlm4F+YFRNPBTAw==',
    expired: null
  }
] to have property length of 4 (got 3)
      at test/integration/branches_revert_memberships.js:188:48
      at next (native)

  3) Revert memberships revert renewal block:

      AssertionError: expected 2 to be 1
      + expected - actual

      -2
      +1
      
      at test/integration/branches_revert_memberships.js:212:47
      at next (native)

  4) Revert memberships revert join block:

      AssertionError: expected 1 to be -1
      + expected - actual

      -1
      +-1
      
      at test/integration/branches_revert_memberships.js:195:47
      at next (native)

  5) Protocol 0.5 Difficulties "before all" hook:
     StatusCodeError: 500 - "{\n  \"ucode\": 1002,\n  \"message\": \"V6 block cannot have medianTime < 1481029200\"\n}"
      at endReadableNT (_stream_readable.js:974:12)
      at _combinedTickCallback (internal/process/next_tick.js:74:11)
      at process._tickCallback (internal/process/next_tick.js:98:9)



error Command failed with exit code 5.
```