### PR TITLE
[enh] return exit values on daemon status

### DIFF
--- a/bin/daemon
+++ b/bin/daemon
@@ -20,10 +20,11 @@ switch (process.argv[2]) {
   case "status":
     if (daemon.status()) {
       console.log('Duniter daemon status: running');
+      process.exit(0)
     } else {
       console.log('Duniter daemon status: stopped');
+      process.exit(2)
     }
-    break;
 
   case "sync":
   case "reset":


### PR DESCRIPTION
#668:
- https://nodejs.org/api/process.html#process_exit_codes
- this will allow me to partially fix:
   - https://github.com/YunoHost-Apps/duniter_ynh/issues/21
   - stop daemon will only be done when daemon running.

```bash
duniter stop
echo $?
2
duniter start
echo $?
0
```