### PR TITLE
[fix]crawler : this is null exceptions

### DIFF
--- a/app/modules/crawler/lib/crawler.ts
+++ b/app/modules/crawler/lib/crawler.ts
@@ -202,7 +202,7 @@ export class PeerTester implements DuniterService {
   async startService() {
     if (this.testPeerFifoInterval)
       clearInterval(this.testPeerFifoInterval);
-    this.testPeerFifoInterval = setInterval(() => this.testPeerFifo.push((cb:any) => this.testPeers.bind(null, this.server, this.conf, !this.FIRST_CALL)().then(cb).catch(cb)), 1000 * CrawlerConstants.TEST_PEERS_INTERVAL);
+    this.testPeerFifoInterval = setInterval(() => this.testPeerFifo.push((cb:any) => this.testPeers.bind(this, this.server, this.conf, !this.FIRST_CALL)().then(cb).catch(cb)), 1000 * CrawlerConstants.TEST_PEERS_INTERVAL);
     await this.testPeers(this.server, this.conf, this.FIRST_CALL);
   }
 


### PR DESCRIPTION
Pull request for code reviewing.

Using VSC debugger with interruption on any exception uncatched, I received many errors because this is null here : https://github.com/duniter/duniter/blob/dev/app/modules/crawler/lib/crawler.ts#L223