### PR TITLE
[fix]#1029 blockstamp in raw documents incoherence

### DIFF
--- a/app/service/PeeringService.ts
+++ b/app/service/PeeringService.ts
@@ -130,6 +130,7 @@ export class PeeringService {
           peerEntityOld.endpoints = thePeer.endpoints
           peerEntityOld.status = thePeer.status
           peerEntityOld.signature = thePeer.signature
+          peerEntityOld.blockstamp = thePeer.block
         }
         // Set the peer as UP again
         const peerEntity = peerEntityOld.toDBPeer()

--- a/test/integration/network-update.js
+++ b/test/integration/network-update.js
@@ -1,0 +1,112 @@
+"use strict";
+
+const co = require('co');
+const _         = require('underscore');
+const rp        = require('request-promise');
+const httpTest  = require('./tools/http');
+const node      = require('./tools/node');
+const user      = require('./tools/user');
+const commit    = require('./tools/commit');
+const sync      = require('./tools/sync');
+const until     = require('./tools/until');
+const toolbox   = require('./tools/toolbox');
+const BlockDTO = require("../../app/lib/dto/BlockDTO");
+
+const expectHttpCode = httpTest.expectHttpCode;
+const expectAnswer = httpTest.expectAnswer;
+
+const MEMORY_MODE = true;
+const commonConf = {
+  ipv4: '127.0.0.1',
+  remoteipv4: '127.0.0.1',
+  currency: 'bb',
+  httpLogs: true,
+  forksize: 3,
+  sigQty: 1
+};
+
+const catKeyPair = {
+  pair: {
+    pub: 'HgTTJLAQ5sqfknMq7yLPZbehtuLSsKj9CxWN7k8QvYJd',
+    sec: '51w4fEShBk1jCMauWu4mLpmDVfHksKmWcygpxriqCEZizbtERA6de4STKRkQBpxmMUwsKXRjSzuQ8ECwmqN1u2DP'
+  }
+};
+
+const tocKeyPair = {
+  pair: {
+    pub: 'DKpQPUL4ckzXYdnDRvCRKAm1gNvSdmAXnTrJZ7LvM5Qo',
+    sec: '64EYRvdPpTfLGGmaX5nijLXRqWXaVz8r1Z1GtaahXwVSJGQRn7tqkxLb288zwSYzELMEG5ZhXSBYSxsTsz1m9y8F'
+  }
+};
+
+const s1 = toolbox.server(_.clone(catKeyPair));
+const s2 = toolbox.server(_.clone(tocKeyPair));
+
+const cat = user('cat', { pub: 'HgTTJLAQ5sqfknMq7yLPZbehtuLSsKj9CxWN7k8QvYJd', sec: '51w4fEShBk1jCMauWu4mLpmDVfHksKmWcygpxriqCEZizbtERA6de4STKRkQBpxmMUwsKXRjSzuQ8ECwmqN1u2DP'}, { server: s1 });
+const toc = user('toc', { pub: 'DKpQPUL4ckzXYdnDRvCRKAm1gNvSdmAXnTrJZ7LvM5Qo', sec: '64EYRvdPpTfLGGmaX5nijLXRqWXaVz8r1Z1GtaahXwVSJGQRn7tqkxLb288zwSYzELMEG5ZhXSBYSxsTsz1m9y8F'}, { server: s1 });
+
+
+describe("Network updating", function() {
+
+  before(function() {
+
+    return co(function *() {
+      const commitS1 = commit(s1);
+      const commitS2 = commit(s2);
+
+      yield [s1, s2].reduce((p, server) => co(function*() {
+        yield p;
+        yield server.initDalBmaConnections()
+        require('../../app/modules/router').duniter.methods.routeToNetwork(server);
+      }), Promise.resolve());
+
+      // Server 1
+      yield cat.createIdentity();
+      yield toc.createIdentity();
+      yield toc.cert(cat);
+      yield cat.cert(toc);
+      yield cat.join();
+      yield toc.join();
+      for (const i in _.range(32)) {
+        yield commitS1(); // block#0
+      }
+      // // s2 syncs from s1
+      yield sync(0, 31, s1, s2);
+
+      const b2 = yield s1.makeNext({});
+      yield s1.postBlock(b2);
+      yield s2.postBlock(b2);
+      yield s1.recomputeSelfPeer(); // peer#1
+      yield s1.sharePeeringWith(s2);
+      const b3 = yield s1.makeNext({});
+      yield s1.postBlock(b3);
+      yield s2.postBlock(b3);
+      yield s1.recomputeSelfPeer(); // peer#1
+      yield s1.sharePeeringWith(s2);
+    });
+  });
+
+    describe("Server 1 /network/peering", function() {
+
+      it('/peers?leaf=LEAFDATA', () => co(function*() {
+        const data = yield s1.get('/network/peering/peers?leaves=true');
+        const leaf = data.leaves[0];
+        const res = yield s1.get('/network/peering/peers?leaf=' + leaf);
+        res.leaf.value.should.have.property("pubkey").equal('HgTTJLAQ5sqfknMq7yLPZbehtuLSsKj9CxWN7k8QvYJd');
+        res.leaf.value.should.have.property("block").match(new RegExp('^3-'));
+        res.leaf.value.should.have.property("raw").match(new RegExp('.*Block: 3-.*'));
+      }));
+    });
+
+    describe("Server 2 /network/peering", function() {
+
+      it('/peers?leaf=LEAFDATA', () => co(function*() {
+        const data = yield s2.get('/network/peering/peers?leaves=true');
+        const leaf = data.leaves[0];
+        const res = yield s2.get('/network/peering/peers?leaf=' + leaf);
+        res.leaf.value.should.have.property("pubkey").equal('DKpQPUL4ckzXYdnDRvCRKAm1gNvSdmAXnTrJZ7LvM5Qo');
+        res.leaf.value.should.have.property("block").match(new RegExp('^0-'));
+        res.leaf.value.should.have.property("raw").match(new RegExp('.*Block: 0-.*'));
+      }));
+    });
+  });

--- a/test/integration/peers-same-pubkey.js
+++ b/test/integration/peers-same-pubkey.js
@@ -100,6 +100,24 @@ describe("Peer document", function() {
       leavesCount: 1
     }));
 
+    it('leaf data', () => co(function*() {
+      const data = yield s1.get('/network/peering/peers?leaves=true');
+      const leaf = data.leaves[0];
+      const res = yield s1.get('/network/peering/peers?leaf=' + leaf);
+      res.leaf.value.should.have.property("pubkey").equal('HgTTJLAQ5sqfknMq7yLPZbehtuLSsKj9CxWN7k8QvYJd');
+      res.leaf.value.should.have.property("block").match(new RegExp('^3-'));
+      res.leaf.value.should.have.property("raw").match(new RegExp('.*Block: 3-.*'));
+      res.leaf.value.should.have.property("endpoints").length(3);
+    }));
+
+
+    it('peers', () => s1.expectThat('/network/peering', (res) => {
+      res.should.have.property("pubkey").equal('HgTTJLAQ5sqfknMq7yLPZbehtuLSsKj9CxWN7k8QvYJd');
+      res.should.have.property("block").match(new RegExp('^3-'));
+      res.should.have.property("endpoints").length(3);
+    }));
+
+
     it('peering should have been updated by node 1', () => s1.expectThat('/network/peering', (res) => {
       res.should.have.property("pubkey").equal('HgTTJLAQ5sqfknMq7yLPZbehtuLSsKj9CxWN7k8QvYJd');
       res.should.have.property("block").match(new RegExp('^3-'));
@@ -118,6 +136,18 @@ describe("Peer document", function() {
       leavesCount: 1
     }));
 
+
+    it('leaf data', () => co(function*() {
+      const data = yield s2.get('/network/peering/peers?leaves=true');
+      const leaf = data.leaves[0];
+      const res = yield s2.get('/network/peering/peers?leaf=' + leaf);
+      res.leaf.value.should.have.property("pubkey").equal('HgTTJLAQ5sqfknMq7yLPZbehtuLSsKj9CxWN7k8QvYJd');
+      res.leaf.value.should.have.property("block").match(new RegExp('^3-'));
+      res.leaf.value.should.have.property("raw").match(new RegExp('.*Block: 3-.*'));
+      res.leaf.value.should.have.property("endpoints").length(3);
+    }));
+
+
     it('peering should have been updated by node 1', () => s2.expectThat('/network/peering', (res) => {
       res.should.have.property("pubkey").equal('HgTTJLAQ5sqfknMq7yLPZbehtuLSsKj9CxWN7k8QvYJd');
       res.should.have.property("block").match(new RegExp('^3-'));
@@ -134,6 +164,16 @@ describe("Peer document", function() {
 
     it('should have a 1 leaves merkle for peers', () => s3.expectJSON('/network/peering/peers', {
       leavesCount: 1
+    }));
+
+    it('leaf data', () => co(function*() {
+      const data = yield s3.get('/network/peering/peers?leaves=true');
+      const leaf = data.leaves[0];
+      const res = yield s3.get('/network/peering/peers?leaf=' + leaf);
+      res.leaf.value.should.have.property("pubkey").equal('HgTTJLAQ5sqfknMq7yLPZbehtuLSsKj9CxWN7k8QvYJd');
+      res.leaf.value.should.have.property("block").match(new RegExp('^3-'));
+      res.leaf.value.should.have.property("raw").match(new RegExp('.*Block: 3-.*'));
+      res.leaf.value.should.have.property("endpoints").length(3);
     }));
 
     it('peering should have been updated by node 1', () => s3.expectThat('/network/peering', (res) => {


### PR DESCRIPTION
Pull request for code reviewing : 

If we follow the state of `peerEntityOld` : 
 - if we found a peer in database, it is built from it
 - if we didn't found a peer, it is built from received peer `thePeer`

When we found a peer, we compare the blockstamp and updates `peerEntityOld` to `thePeer` values **only** if it is more recent.

But when we update `peerEntityOld`, the `blockstamp` field is not updated ! Thus, the `peerEntity` objects gets corrupted with 2 different data : 
 - `peerEntity.block` is the most recent, from `thePeer.block`
 - `peerEntity.raw` is the older data, from `peerEntityOld.getRaw()`

And peerEntity gets saved in database...

PS : If  there is a part of the code which you would like to clean, I would start with this PeeringService code, it's pretty hard to follow the states of the different variables other here ^^ 