### PR TITLE
[fix] return exit values on daemon status.

### DIFF
--- a/app/modules/daemon.ts
+++ b/app/modules/daemon.ts
@@ -69,8 +69,10 @@ module.exports = {
         const pid = server.getDaemon().status()
         if (pid) {
           console.log('Duniter is running using PID %s.', pid)
+          process.exit(0)
         } else {
           console.log('Duniter is not running.')
+          process.exit(2)
         }
       }
     }, {


### PR DESCRIPTION
It haven't been migrate with TS migration.

Same as https://github.com/duniter/duniter/pull/922.