### PR TITLE
[sec] update 'ws' dependency as a there is a security issue.

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "unzip2": "0.2.5",
     "winston": "2.3.1",
     "wotb": "0.6.x",
-    "ws": "1.1.1"
+    "ws": "1.1.5"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.41",


### PR DESCRIPTION
[There is a security issue with 'ws' module](https://david-dm.org/duniter/duniter)                                        
Upgrade ws dependency to 1.1.5 which fix it.

---

Concerning migrating it to last versions 2 and 3, here is changelogs:
- https://github.com/websockets/ws/releases/tag/2.0.0
- https://github.com/websockets/ws/releases/tag/3.0.0

We could update it to 3.3.1.
greping the code, `ws.open` and `ws.send` methods are used.