### PR TITLE
[fix] #1090 `--cautious` option was broken

### DIFF
--- a/app/modules/crawler/lib/sync.ts
+++ b/app/modules/crawler/lib/sync.ts
@@ -258,7 +258,8 @@ export class Synchroniser extends stream.Duplex {
           return block;
         }
         async applyMainBranch(block: BlockDTO): Promise<boolean> {
-          const addedBlock = await this.BlockchainService.submitBlock(block)
+          const addedBlock = await this.BlockchainService.submitBlock(block, true)
+          await this.BlockchainService.blockResolution()
           this.server.streamPush(addedBlock);
           this.watcher.appliedPercent(Math.floor(block.number / to * 100));
           return true


### PR DESCRIPTION
La solution est simple : la procédure de synchro doit *attendre* que le bloc ait été ajouté avant de passer au suivant. Sans cela, la synchro s'arrête au bloc 249.