### PR TITLE
Change gitlab url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Initial disclaimer
 This project is now tracked on our hosted gitlab server at:
-https://git-sandbox.duniter.org/nodes/typescript/duniter
+https://git.duniter.org/nodes/typescript/duniter
 
 The current github repository is a simple clone taken up to date at each push on the main gitlab repository.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
+# Initial disclaimer
+This project is now tracked on our hosted gitlab server at:
+https://git-sandbox.duniter.org/nodes/typescript/duniter
+
+The current github repository is a simple clone taken up to date at each push on the main gitlab repository.
+
+All contributions should be performed on the main gitlab repository.
+
+Pull requests proposed on github would generate more work for the main contributors.
+
+Issues can be submitted on github. However, all issues created on github will be duplicated on gitlab manually and closed with a link to the gitlab issue.
+
+
+# Original README.md
+
 ![Duniter logo](https://raw.github.com/duniter/duniter/master/images/250×250.png)
 
 # Duniter [![Build Status](https://api.travis-ci.org/duniter/duniter.png)](https://travis-ci.org/duniter/duniter) [![Coverage Status](https://coveralls.io/repos/github/duniter/duniter/badge.svg?branch=master)](https://coveralls.io/github/duniter/duniter?branch=master) [![Dependencies](https://david-dm.org/duniter/duniter.svg)](https://david-dm.org/duniter/duniter)


### PR DESCRIPTION
This project is now tracked on our hosted gitlab server at:
https://git.duniter.org/nodes/typescript/duniter/gitlab

The current github repository is a simple clone taken up to date at each push on the main gitlab repository.

All contributions should be performed on the main gitlab repository.

Pull requests proposed on github would generate more work for the main contributors, therefore we would really appreciate if you can create instead merge requests on our hosted gitlab instance.

Thank you for your understanding.
